### PR TITLE
MNT Resolve CI problems

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,7 +1,10 @@
 <?xml version="1.0"?>
 <ruleset name="PSR12">
- <rule ref="PSR12"/>
- <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
-    <exclude-pattern>tests/bootstrap\.php</exclude-pattern>
-</rule>
+    <rule ref="PSR12"/>
+    <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
+        <exclude-pattern>tests/bootstrap\.php</exclude-pattern>
+    </rule>
+
+    <file>./src</file>
+    <file>./tests</file>
 </ruleset>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,9 @@
 <?php
 
 // php_codesniffer autoloader
+
+use PHP_CodeSniffer\Util\Tokens;
+
 $autoloadCandidates = [
     // running from package itself as root
     __DIR__ . '/../vendor/squizlabs/php_codesniffer/autoload.php',
@@ -16,6 +19,15 @@ foreach ($autoloadCandidates as $candidate) {
         break;
     }
 }
+
+if (!$autoloaded) {
+    throw new RuntimeException("Couldn't find autoloader");
+}
+
+// Required to correctly run constant definitions in CI, though not needed locally for some reason.
+// Referencing a static property on the Tokens class forces the file containing it to be autoloaded,
+// which results in the constants (defined in the same file) being defined ahead of time.
+Tokens::$operators;
 
 if (!defined('PHP_CODESNIFFER_VERBOSITY')) {
     define('PHP_CODESNIFFER_VERBOSITY', 0);


### PR DESCRIPTION
Linting and unit tests are failing - see https://github.com/silverstripe/markdown-php-codesniffer/actions/runs/6844025973

- Tell phpcs what to sniff
- Throw a hard error if we can't bootstrap tests correctly (I had intended to do that in #1 but it got missed out)
- Force `Tokens.php` to be run for constant declarations (needed in CI for some reason, but not needed locally)

## Issue
- https://github.com/silverstripe/developer-docs/issues/11