### PR TITLE
DEP Change minimum PHP version to 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "squizlabs/php_codesniffer": "^3.7",
         "league/commonmark": "^2.4"
     },


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-merge-up/issues/28

Bumping this purely to satisfy https://github.com/silverstripe/gha-merge-up/blob/1/funcs.php#L82 since 8.1 is a standard minimum version for CMS 5 modules. There's no practical need to run this module on something that has php 8.0 installed but not 8.1.

I've tested this PR in a merge-up action run where I had changed the PHP version to ^8.1 in composer.json on the `1` branch - https://github.com/emteknetnz/markdown-php-codesniffer/actions/runs/7040354233


