### PR TITLE
Revert "DEP Use PHPUnit 11"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,6 @@
         "bin/mdphpcs"
     ],
     "require-dev": {
-        "phpunit/phpunit": "^11.3"
+        "phpunit/phpunit": "^9.6"
     }
 }

--- a/tests/SnifferTest.php
+++ b/tests/SnifferTest.php
@@ -7,14 +7,14 @@ use PHP_CodeSniffer\Ruleset;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use SilverStripe\MarkdownPhpCodeSniffer\Sniffer;
-use PHPUnit\Framework\Attributes\DataProvider;
 
 class SnifferTest extends TestCase
 {
     /**
      * Validates that fenced code blocks are correctly identified and have the expected data
+     *
+     * @dataProvider provideFindFencedBlocks
      */
-    #[DataProvider('provideFindFencedBlocks')]
     public function testFindFencedCodeBlocks(
         string $path,
         bool $exists,
@@ -48,7 +48,7 @@ class SnifferTest extends TestCase
         }
     }
 
-    public static function provideFindFencedBlocks()
+    public function provideFindFencedBlocks()
     {
         return [
             'nothing to lint 1' => [


### PR DESCRIPTION
This reverts https://github.com/silverstripe/markdown-php-codesniffer/pull/13.

Fixes https://github.com/silverstripe/markdown-php-codesniffer/actions/runs/10915100322/job/30294505538
> Your requirements could not be resolved to an installable set of packages.

The tests are only run on PHP versions that aren't compatible with PHPUnit 11

## Issue
- https://github.com/silverstripe/.github/issues/313